### PR TITLE
Allow cell execution timeout to be overridden in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ mknotebooks is a plugin for [MkDocs](https://mkdocs.org), which makes it more co
 
 Simply include any notebooks you want to use in the docs source directory, and add mknotebooks to the plugin section of your `mkdocs.yml`.
 
-You can optionally execute the notebooks, by setting `execute: true` in the config, and include a hidden preamble script, to be run before executing any cells using `preamble: "<path/to/your/script>"`.
+You can optionally execute the notebooks, by setting `execute: true` in the config, and include a hidden preamble script, to be run before executing any cells using `preamble: "<path/to/your/script>"`. The default cell execution timeout can be overridden by setting `timeout: <timeout>`, where `<timeout>` is an integer number of seconds.
 
 Any static images, plots, etc. will be extracted from the notebook and placed alongside the output HTML.
 

--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -28,6 +28,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
     config_scheme = (
         ("execute", mkdocs.config.config_options.Type(bool, default=False)),
         ("preamble", mkdocs.config.config_options.FilesystemObject()),
+        ("timeout", mkdocs.config.config_options.Type(int)),
     )
 
     def on_config(self, config):
@@ -44,6 +45,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
                     "nbconvert_utils.ExecuteWithPreamble",
                 )
                 c.default_preprocessors = default_preprocessors
+                c.ExecutePreprocessor.timeout = self.config["timeout"]
                 c.ExecuteWithPreamble.enabled = True
                 c.ExecuteWithPreamble.preamble_scripts = [self.config["preamble"]]
             else:


### PR DESCRIPTION
Closes #1 

Adds a new config option `timeout`, which overrides the default `nbconvert` cell execution timeout.

E.g. to set the cell execution timeout to 60 seconds, a user can set

```
plugins:
  - mknotebooks:
      execute: true
      timeout: 60
```

in their `mkdocs.yml` config.