### PR TITLE
Custom CSS for input and output cells

### DIFF
--- a/mknotebooks/templates/custom_markdown.tpl
+++ b/mknotebooks/templates/custom_markdown.tpl
@@ -1,0 +1,36 @@
+{#
+   This template extends the standard nbconvert markdown template in
+   such a way that input and output cells are wrapped in custom <div>
+   tags which are marked with the CSS classes "jupyterInputCell" and
+   "jupyterOutputCell". This allows us to use our own custom styling
+   for input and output cells. Note that this works because it is
+   valid to use raw HTML in markdown.
+
+   When converted to markdown, input cells are formatted using code
+   blocks that use triple backticks, and these can be wrapped directly
+   in a <div>.
+
+   By contrast, output cells are by default formatted using simply
+   an indented block (rather than triple backticks). Such an indented
+   block cannot directly be wrapped in a <div> without losing the
+   formatting. Therefore we first apply a custom Jinja filter to
+   each line of the output cell which removes the indentation, and
+   then surround the result with triple backticks and finally wrap
+   this in the custom <div>.
+#}
+
+{% extends "markdown.tpl" %}
+
+{% block input_group %}
+<div class='jupyterInputCell'>
+{{ super() }}
+</div>
+{% endblock input_group %}
+
+{% block output_group %}
+<div class='jupyterOutputCell'>
+```
+{{ super().split('\n') | map('remove_leading_indentation') | join('\n') }}
+```
+</div>
+{% endblock output_group %}


### PR DESCRIPTION
This PR addresses #3.

It adds a custom nbconvert template which wraps the generated markdown of input/output cells in a Jupyter notebook in custom `<div>` tags which are marked with the CSS classes `jupyterInputCell` and `jupyterOutputCell`.

These `<div>` tags are preserved by the `codehilite` extension, which allows the user to apply custom CSS styling in order to format input and output cells differently as desired.

---

Simple example:
```
# Add this to mkdocs.yml:

extra_css:
  - css/extra.css
```

```
# Contents of css/extra.css:

.jupyterInputCell {
    background-color: #00ff0022;
}

.jupyterOutputCell {
    background-color: #ff000011;
}
```

The result looks like this: 
<img width="600" alt="screenshot_example" src="https://user-images.githubusercontent.com/2692805/74484181-ff701400-4eaf-11ea-8cf5-5d567c8c7621.png">

---

It would be nice if we could ship with a nice default (probably less colourful than the above example ;)). Is it possible to tweak the default CSS in `mknotebooks` directly so that the user doesn't have to do it themselves in every project?
