### PR TITLE
Add CSS for pandas dataframes and different styling of input/output cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 
+- Added default CSS stylesheets for nicer styling of notebook input/output cells and pandas dataframes,
+  as well as two options (`enable-default-jupyter-cell-styling`, `enable-default-pandas-dataframe-styling`)
+  to enable or disable them [#13](https://github.com/greenape/mknotebooks/pull/13)  (thanks to [@maxalbert](https://github.com/maxalbert))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added default CSS stylesheets for nicer styling of notebook input/output cells and pandas dataframes,
-  as well as two options (`enable-default-jupyter-cell-styling`, `enable-default-pandas-dataframe-styling`)
+  as well as two options (`enable_default_jupyter_cell_styling`, `enable_default_pandas_dataframe_styling`)
   to enable or disable them [#13](https://github.com/greenape/mknotebooks/pull/13)  (thanks to [@maxalbert](https://github.com/maxalbert))
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Any static images, plots, etc. will be extracted from the notebook and placed al
 Mknotebooks applies default styling to improve the appearance of notebook input/output cells and pandas dataframes. If these interfere with any other CSS stylesheets that you're using, you can disable these via the following options.
 ```
 - mknotebooks:
-   enable-default-jupyter-cell-styling: false
-   enable-default-pandas-dataframe-styling: false
+   enable_default_jupyter_cell_styling: false
+   enable_default_pandas_dataframe_styling: false
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ mknotebooks is a plugin for [MkDocs](https://mkdocs.org), which makes it more co
 Simply include any notebooks you want to use in the docs source directory, and add mknotebooks to the plugin section of your `mkdocs.yml`.
 
 You can optionally execute the notebooks, by setting `execute: true` in the config, and include a hidden preamble script, to be run before executing any cells using `preamble: "<path/to/your/script>"`. The default cell execution timeout can be overridden by setting `timeout: <timeout>`, where `<timeout>` is an integer number of seconds.
+By default, execution will be aborted if any of the cells throws an error, but you can set `allow_errors: true` to continue execution and include the error message in the cell output.
 
 Any static images, plots, etc. will be extracted from the notebook and placed alongside the output HTML.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ By default, execution will be aborted if any of the cells throws an error, but y
 
 Any static images, plots, etc. will be extracted from the notebook and placed alongside the output HTML.
 
+Mknotebooks applies default styling to improve the appearance of notebook input/output cells and pandas dataframes. If these interfere with any other CSS stylesheets that you're using, you can disable these via the following options.
+```
+- mknotebooks:
+   enable-default-jupyter-cell-styling: false
+   enable-default-pandas-dataframe-styling: false
+```
+
 ## Example
 
 An [example docs project](examples/execute_with_preamble) demonstrating the above is included. Try it out by running `pipenv install && pipenv run mkdocs serve`.

--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -17,19 +17,6 @@ log = logging.getLogger(__name__)
 here = os.path.dirname(os.path.abspath(__file__))
 
 
-def remove_leading_indentation(s):
-    """
-    Custom Jinja filter which removes leading indentation (= exactly four spaces)
-    from a string and returns the result.
-
-    If the input string does not start with four spaces it is returned unchanged).
-    """
-    if s.startswith("    "):
-        return s[4:]
-    else:
-        return s
-
-
 class NotebookFile(mkdocs.structure.files.File):
     """
     Wraps a regular File object to make ipynb files appear as
@@ -108,9 +95,6 @@ class Plugin(mkdocs.plugins.BasePlugin):
                 os.path.join(built_in_templates, "html"),
                 os.path.join(built_in_templates, "skeleton"),
             ],
-        )
-        exporter.register_filter(
-            "remove_leading_indentation", remove_leading_indentation
         )
 
         config["notebook_exporter"] = exporter

--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import pathlib
-from shutil import copy
 
 import mkdocs
 import nbconvert

--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -42,8 +42,8 @@ class Plugin(mkdocs.plugins.BasePlugin):
         ("preamble", mkdocs.config.config_options.FilesystemObject()),
         ("timeout", mkdocs.config.config_options.Type(int)),
         ("write_markdown", mkdocs.config.config_options.Type(bool, default=False)),
-        ("enable-default-jupyter-cell-styling", mkdocs.config.config_options.Type(bool, default=True)),
-        ("enable-default-pandas-dataframe-styling", mkdocs.config.config_options.Type(bool, default=True)),
+        ("enable_default_jupyter_cell_styling", mkdocs.config.config_options.Type(bool, default=True)),
+        ("enable_default_pandas_dataframe_styling", mkdocs.config.config_options.Type(bool, default=True)),
     )
 
     def on_config(self, config):
@@ -100,9 +100,9 @@ class Plugin(mkdocs.plugins.BasePlugin):
 
         config["notebook_exporter"] = exporter
         config["extra_css"].append(os.path.join("css", "ansi-colours.css"))
-        if self.config["enable-default-jupyter-cell-styling"]:
+        if self.config["enable_default_jupyter_cell_styling"]:
             config["extra_css"].append(os.path.join("css", "jupyter-cells.css"))
-        if self.config["enable-default-pandas-dataframe-styling"]:
+        if self.config["enable_default_pandas_dataframe_styling"]:
             config["extra_css"].append(os.path.join("css", "pandas-dataframe.css"))
         return config
 

--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -116,6 +116,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
         config["notebook_exporter"] = exporter
         config["extra_css"].append(os.path.join("css", "ansi-colours.css"))
         config["extra_css"].append(os.path.join("css", "pandas-dataframe.css"))
+        config["extra_css"].append(os.path.join("css", "jupyter-cells.css"))
         return config
 
     def on_files(self, files, config):
@@ -133,6 +134,12 @@ class Plugin(mkdocs.plugins.BasePlugin):
             dest_dir=css_dest_dir,
             use_directory_urls=False,
         )
+        jupyter_cells_css = File(
+            path="jupyter-cells.css",
+            src_dir=templates_dir,
+            dest_dir=css_dest_dir,
+            use_directory_urls=False,
+        )
         files = Files(
             [
                 NotebookFile(f, **config)
@@ -140,7 +147,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
                 else f
                 for f in files
             ]
-            + [ansi_colours_css, pandas_dataframe_css]
+            + [ansi_colours_css, pandas_dataframe_css, jupyter_cells_css]
         )
         return files
 

--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -47,7 +47,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
     )
 
     def on_config(self, config):
-        c = Config()
+        exporter_config = Config()
         if self.config["execute"]:
             default_preprocessors = MarkdownExporter.default_preprocessors.default_args[
                 0
@@ -57,17 +57,17 @@ class Plugin(mkdocs.plugins.BasePlugin):
                     "nbconvert.preprocessors.ExecutePreprocessor"
                 )
             ] = ExtraArgsExecutePreprocessor
-            c.default_preprocessors = default_preprocessors
-            c.ExecutePreprocessor.timeout = self.config["timeout"]
-            c.ExecutePreprocessor.allow_errors = self.config["allow_errors"]
-            c.ExtraArgsExecutePreprocessor.enabled = True
-            c.ExtractOutputPreprocessor.enabled = True
+            exporter_config.default_preprocessors = default_preprocessors
+            exporter_config.ExecutePreprocessor.timeout = self.config["timeout"]
+            exporter_config.ExecutePreprocessor.allow_errors = self.config["allow_errors"]
+            exporter_config.ExtraArgsExecutePreprocessor.enabled = True
+            exporter_config.ExtractOutputPreprocessor.enabled = True
             preamble = [os.path.join(here, "pandas_output_formatter.py")]
 
-            c.file_extension = ".md"
+            exporter_config.file_extension = ".md"
             if self.config["preamble"]:
                 preamble.append(self.config["preamble"])
-            c.ExtraArgsExecutePreprocessor.extra_arguments = [
+            exporter_config.ExtraArgsExecutePreprocessor.extra_arguments = [
                 f"--InteractiveShellApp.exec_files={preamble}",
             ]
 
@@ -75,7 +75,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
         built_in_templates = os.path.join(
             os.path.dirname(nbconvert.__file__), "templates"
         )
-        c.NbConvertBase.display_data_priority = [
+        exporter_config.NbConvertBase.display_data_priority = [
             "application/vnd.jupyter.widget-state+json",
             "application/vnd.jupyter.widget-view+json",
             "application/javascript",
@@ -88,7 +88,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
             "text/plain",
         ]
         exporter = HTMLExporter(
-            config=c,
+            config=exporter_config,
             template_file=template_file,
             template_path=[
                 os.path.join(here, "templates"),

--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -115,13 +115,22 @@ class Plugin(mkdocs.plugins.BasePlugin):
 
         config["notebook_exporter"] = exporter
         config["extra_css"].append(os.path.join("css", "ansi-colours.css"))
+        config["extra_css"].append(os.path.join("css", "pandas-dataframe.css"))
         return config
 
     def on_files(self, files, config):
+        templates_dir = os.path.join(here, "templates")
+        css_dest_dir = os.path.join(config["site_dir"], "css")
         ansi_colours_css = File(
             path="ansi-colours.css",
-            src_dir=os.path.join(here, "templates"),
-            dest_dir=os.path.join(config["site_dir"], "css"),
+            src_dir=templates_dir,
+            dest_dir=css_dest_dir,
+            use_directory_urls=False,
+        )
+        pandas_dataframe_css = File(
+            path="pandas-dataframe.css",
+            src_dir=templates_dir,
+            dest_dir=css_dest_dir,
             use_directory_urls=False,
         )
         files = Files(
@@ -131,7 +140,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
                 else f
                 for f in files
             ]
-            + [ansi_colours_css]
+            + [ansi_colours_css, pandas_dataframe_css]
         )
         return files
 

--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -42,6 +42,8 @@ class Plugin(mkdocs.plugins.BasePlugin):
         ("preamble", mkdocs.config.config_options.FilesystemObject()),
         ("timeout", mkdocs.config.config_options.Type(int)),
         ("write_markdown", mkdocs.config.config_options.Type(bool, default=False)),
+        ("enable-default-jupyter-cell-styling", mkdocs.config.config_options.Type(bool, default=True)),
+        ("enable-default-pandas-dataframe-styling", mkdocs.config.config_options.Type(bool, default=True)),
     )
 
     def on_config(self, config):
@@ -98,8 +100,10 @@ class Plugin(mkdocs.plugins.BasePlugin):
 
         config["notebook_exporter"] = exporter
         config["extra_css"].append(os.path.join("css", "ansi-colours.css"))
-        config["extra_css"].append(os.path.join("css", "pandas-dataframe.css"))
-        config["extra_css"].append(os.path.join("css", "jupyter-cells.css"))
+        if self.config["enable-default-jupyter-cell-styling"]:
+            config["extra_css"].append(os.path.join("css", "jupyter-cells.css"))
+        if self.config["enable-default-pandas-dataframe-styling"]:
+            config["extra_css"].append(os.path.join("css", "pandas-dataframe.css"))
         return config
 
     def on_files(self, files, config):

--- a/mknotebooks/templates/jupyter-cells.css
+++ b/mknotebooks/templates/jupyter-cells.css
@@ -1,10 +1,10 @@
 /* Input cells */
-.md-typeset .input code, .md-typeset .input pre {
+.input code, .input pre {
     background-color: #3333aa11;
 }
 
 /* Output cells */
-.md-typeset .output pre {
+.output pre {
     /* add a different background color here if you want to change the default */
     padding: 10px;
 }

--- a/mknotebooks/templates/jupyter-cells.css
+++ b/mknotebooks/templates/jupyter-cells.css
@@ -5,6 +5,6 @@
 
 /* Output cells */
 .output pre {
-    /* add a different background color here if you want to change the default */
+    background-color: #ececec80;
     padding: 10px;
 }

--- a/mknotebooks/templates/jupyter-cells.css
+++ b/mknotebooks/templates/jupyter-cells.css
@@ -1,0 +1,10 @@
+/* Input cells */
+.md-typeset .input code, .md-typeset .input pre {
+    background-color: #3333aa11;
+}
+
+/* Output cells */
+.md-typeset .output pre {
+    /* add a different background color here if you want to change the default */
+    padding: 10px;
+}

--- a/mknotebooks/templates/pandas-dataframe.css
+++ b/mknotebooks/templates/pandas-dataframe.css
@@ -1,0 +1,36 @@
+/* Pretty Pandas Dataframes */
+.dataframe {
+    border: 0;
+    font-size: smaller;
+}
+
+.dataframe tr {
+    border: none;
+    background: #ffffff;
+}
+.dataframe tr:nth-child(even) {
+    background: #f5f5f5;
+}
+.dataframe tr:hover {
+    background-color: #e1f5fe;
+}
+
+.dataframe thead th {
+    background: #fff;
+    border-bottom: 1px solid #aaa;
+    font-weight: bold;
+}
+.dataframe th {
+    border: none;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+.dataframe td{
+    /* background: #fff; */
+    border: none;
+    text-align: right;
+    min-width:5em;
+    padding-left: 10px;
+    padding-right: 10px;
+}


### PR DESCRIPTION
What it says on the tin: this PR adds two CSS files: one for prettier display of pandas dataframes, and another one to apply different background colours to input and output cells (which properly fixes #3). Feel free to tweak the background colour of input cells if you prefer a different one.

---

**Before:**
<img width="699" alt="Screen Shot 2020-02-19 at 23 31 07" src="https://user-images.githubusercontent.com/2692805/74886523-4ce8f700-5370-11ea-9705-68e8cdc658d7.png">

---
**After:**
<img width="696" alt="Screen Shot 2020-02-19 at 23 31 34" src="https://user-images.githubusercontent.com/2692805/74886547-5c684000-5370-11ea-9b99-92a1a552579b.png">
