### PR TITLE
Fix compatibility with mkdocs 1.1

### DIFF
--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -135,7 +135,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
         )
         return files
 
-    def on_page_read_source(self, _, page, config):
+    def on_page_read_source(self, page, config):
         if str(page.file.abs_src_path).endswith("ipynb"):
             with open(page.file.abs_src_path) as nbin:
                 nb = nbformat.read(nbin, 4)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     keywords="mkdocs documentation markdown",
     packages=["mknotebooks"],
     include_package_data=True,
-    install_requires=["nbconvert", "mkdocs", "jupyter_client"],
+    install_requires=["nbconvert", "mkdocs>=1.1", "jupyter_client"],
     platforms=["MacOS X", "Linux"],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
`master` currently fails when used together with `mkdocs==1.1` with the following error message:
```
ERROR   -  Error reading page 'index.md': on_page_read_source() missing 1 required positional argument: '_'
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/site-packages/mkdocs/__main__.py", line 199, in <module>
    cli()
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/mkdocs/__main__.py", line 143, in serve_command
    **kwargs
  File "/usr/local/lib/python3.7/site-packages/mkdocs/commands/serve.py", line 141, in serve
    config = builder()
  File "/usr/local/lib/python3.7/site-packages/mkdocs/commands/serve.py", line 136, in builder
    build(config, live_server=live_server, dirty=dirty)
  File "/usr/local/lib/python3.7/site-packages/mkdocs/commands/build.py", line 274, in build
    _populate_page(file.page, config, files, dirty)
  File "/usr/local/lib/python3.7/site-packages/mkdocs/commands/build.py", line 167, in _populate_page
    page.read_source(config)
  File "/usr/local/lib/python3.7/site-packages/mkdocs/structure/pages.py", line 124, in read_source
    'page_read_source', page=self, config=config
  File "/usr/local/lib/python3.7/site-packages/mkdocs/plugins.py", line 96, in run_event
    result = method(**kwargs)
TypeError: on_page_read_source() missing 1 required positional argument: '_'
```

This PR fixes the problem. Unfortunately this also break compatibility with `mkdocs==1.0.*` in some cases so I incremented the required minimal `mkdocs` version.