### PR TITLE
Fix headerlink CSS class

### DIFF
--- a/mknotebooks/plugin.py
+++ b/mknotebooks/plugin.py
@@ -143,6 +143,9 @@ class Plugin(mkdocs.plugins.BasePlugin):
             exporter = config["notebook_exporter"]
             body, resources = exporter.from_notebook_node(nb)
 
+            # nbconvert uses the anchor-link class, convert it to the mkdocs convention
+            body = body.replace('class="anchor-link"', 'class="headerlink"')
+
             if self.config["write_markdown"]:
                 pathlib.Path(page.file.abs_dest_path).parent.mkdir(
                     parents=True, exist_ok=True


### PR DESCRIPTION
`nbconvert` uses the [`anchor-link`](https://github.com/jupyter/nbconvert/blob/275f7f909a803560e2459642a539874113fba959/nbconvert/filters/strings.py#L106) class name for anchor links where as `mkdocs` uses a [`headerlink`](https://github.com/mkdocs/mkdocs/blob/2935b69a8fa9e246cdf6733b6db4fbc5f023e6e6/mkdocs/themes/mkdocs/css/base.css#L205-L214) class name.

This change converts the `anchor-link` class to `headerlink` to fix the CSS. I'm not sure if this can be done in a better way, but for now this should work.