### PR TITLE
Wrap console output in code tag

### DIFF
--- a/mknotebooks/templates/custom_markdown.tpl
+++ b/mknotebooks/templates/custom_markdown.tpl
@@ -103,7 +103,9 @@ unknown type  {{ cell.type }}
 {% block stream_stdout -%}
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>
+<code>
 {{- output.text | ansi2html -}}
+</code>
 </pre>
 </div>
 {%- endblock stream_stdout %}
@@ -111,7 +113,9 @@ unknown type  {{ cell.type }}
 {% block stream_stderr -%}
 <div class="output_subarea output_stream output_stderr output_text">
 <pre>
+<code>
 {{- output.text | ansi2html -}}
+</code>
 </pre>
 </div>
 {%- endblock stream_stderr %}
@@ -209,7 +213,9 @@ alt="{{ alttext }}"
 {%- block data_text scoped %}
 <div class="output_text output_subarea {{ extra_class }}">
 <pre>
+<code>
 {{- output.data['text/plain'] | ansi2html -}}
+</code>
 </pre>
 </div>
 {%- endblock -%}


### PR DESCRIPTION
Console output in Jupyter is often ment to be rendered in a terminal environment with ANSI colours so many frontends (e.g. nteract) wrap the text output in `<code>` tags to consistently style it.

In MkDocs themes that come with custom CSS for code environments like https://squidfunk.github.io/mkdocs-material/, the default styles of `mknotebooks` doen't fit well into the over all design. However removing the default styling results in broken rendering since the console output is interpreted as normal markdown text.

This PR fixes it by wrapping `stdout`, `stderr` and `text/plain` output in `<code>` tags which allows users to customize the output rendering with only small modifications.

## master
`enable_default_jupyter_cell_styling=false` no custom CSS
<img width="723" alt="Screenshot 2020-04-23 at 02 22 21" src="https://user-images.githubusercontent.com/13285808/80048854-4cecab00-8509-11ea-83de-f3fd72901f0c.png">


## PR
`enable_default_jupyter_cell_styling=false` no custom CSS
<img width="720" alt="Screenshot 2020-04-23 at 02 08 52" src="https://user-images.githubusercontent.com/13285808/80048756-fb442080-8508-11ea-9dfc-245dbe02a0be.png">